### PR TITLE
Offline-enable website

### DIFF
--- a/bin/mwop.net.php
+++ b/bin/mwop.net.php
@@ -19,7 +19,7 @@ use ZF\Console\Application;
 chdir(__DIR__ . '/../');
 require_once 'vendor/autoload.php';
 
-define('VERSION', '0.0.2');
+define('VERSION', '0.0.3');
 
 $container = require 'config/container.php';
 

--- a/bin/mwop.net.php
+++ b/bin/mwop.net.php
@@ -130,6 +130,22 @@ $routes = [
             return $handler($route, $console);
         },
     ],
+    [
+        'name' => 'prep-offline-pages',
+        'route' => '[--serviceWorker=]',
+        'description' => 'Prepare the offline pages list for the service-worker.js file.',
+        'short_description' => 'Prep offline page cache list',
+        'options_descriptions' => [
+            '--serviceWorker' => 'Path to the service-worker.js file',
+        ],
+        'defaults' => [
+            'serviceWorker'   => realpath(getcwd()) . '/public/service-worker.js',
+        ],
+        'handler' => function ($route, $console) use ($container) {
+            $handler = $container->get('Mwop\Console\PrepOfflinePages');
+            return $handler($route, $console);
+        },
+    ],
 ];
 
 $app = new Application(

--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,8 @@
     },
     "require-dev": {
         "zfcampus/zf-deploy": "~1.0@stable",
-        "filp/whoops": "^1.1"
+        "filp/whoops": "^1.1",
+        "herrera-io/version": "^1.1"
     },
     "autoload": {
         "psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "97cc9e4261b2210cb22111b89575ee9b",
-    "content-hash": "64db5fef06db2a68bc9342ee9a29003c",
+    "hash": "4072eeb64d728ff5f1a502d1052d77f3",
+    "content-hash": "799b816f4507dd6052790b9636df367e",
     "packages": [
         {
             "name": "aura/router",
@@ -2336,6 +2336,57 @@
                 "update"
             ],
             "time": "2013-10-30 17:23:01"
+        },
+        {
+            "name": "herrera-io/version",
+            "version": "1.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/kherge-abandoned/php-version.git",
+                "reference": "d39d9642b92a04d8b8a28b871b797a35a2545e85"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/kherge-abandoned/php-version/zipball/d39d9642b92a04d8b8a28b871b797a35a2545e85",
+                "reference": "d39d9642b92a04d8b8a28b871b797a35a2545e85",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "require-dev": {
+                "herrera-io/phpunit-test-case": "1.*",
+                "phpunit/phpunit": "3.7.*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Herrera\\Version": "src/lib"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Kevin Herrera",
+                    "email": "kevin@herrera.io",
+                    "homepage": "http://kevin.herrera.io"
+                }
+            ],
+            "description": "A library for creating, editing, and comparing semantic versioning numbers.",
+            "homepage": "http://github.com/herrera-io/php-version",
+            "keywords": [
+                "semantic",
+                "version"
+            ],
+            "time": "2014-05-27 05:29:25"
         },
         {
             "name": "justinrainbow/json-schema",

--- a/config/autoload/dependencies.global.php
+++ b/config/autoload/dependencies.global.php
@@ -23,6 +23,7 @@ return ['dependencies' => [
         Blog\Console\FeedGenerator::class => Blog\Console\FeedGeneratorFactory::class,
         Blog\Console\TagCloud::class      => Blog\Console\TagCloudFactory::class,
         Blog\Mapper::class                => Blog\MapperFactory::class,
+        Console\PrepOfflinePages::class   => Factory\PrepOfflinePagesFactory::class,
         Github\AtomReader::class          => Github\AtomReaderFactory::class,
         Github\Console\Fetch::class       => Github\Console\FetchFactory::class,
         Application::class                => ApplicationFactory::class,

--- a/config/autoload/routes.global.php
+++ b/config/autoload/routes.global.php
@@ -31,6 +31,7 @@ return [
             HomePage::class                   => Factory\PageFactory::class,
             Job\GithubFeed::class             => Job\GithubFeedFactory::class,
             ResumePage::class                 => Factory\PageFactory::class,
+            'Mwop\OfflinePage'                => Factory\PageFactory::class,
         ],
     ],
 
@@ -46,6 +47,12 @@ return [
             'middleware'      => ComicsPage::class,
             'allowed_methods' => ['GET'],
             'name'            => 'comics',
+        ],
+        [
+            'path'            => '/offline',
+            'middleware'      => 'Mwop\OfflinePage',
+            'allowed_methods' => ['GET'],
+            'name'            => 'offline',
         ],
         [
             'path'            => '/resume',

--- a/public/js/site.js
+++ b/public/js/site.js
@@ -1,0 +1,5 @@
+if (navigator.serviceWorker) {
+  navigator.serviceWorker.register('/service-worker.js', {
+    scope: '/'
+  });
+}

--- a/public/service-worker.js
+++ b/public/service-worker.js
@@ -2,13 +2,11 @@
 var version = 'v0.0.2:';
 
 /* Pages to cache by default */
-/* @generator-marker@ */
 var offline = [
   '/',
   '/offline',
   '/resume'
 ];
-/* @/generator-marker@ */
 
 /* Cache up to 25 pages locally */
 var pageCacheLimit = 25;

--- a/public/service-worker.js
+++ b/public/service-worker.js
@@ -1,11 +1,22 @@
 /* Ends with ':' so it can be used with cache identifiers */
-var version = 'v0.0.2:';
+var version = 'v0.0.3:'
 
 /* Pages to cache by default */
 var offline = [
-  '/',
-  '/offline',
-  '/resume'
+    "/",
+    "/blog",
+    "/offline",
+    "/resume",
+    "/blog/2015-09-19-zend-10-year-anniversary.html",
+    "/blog/2015-09-09-composer-root.html",
+    "/blog/2015-07-28-on-psr7-headers.html",
+    "/blog/2015-06-08-php-is-20.html",
+    "/blog/2015-05-18-psr-7-accepted.html",
+    "/blog/2015-05-15-splitting-components-with-git.html",
+    "/blog/2015-01-26-psr-7-by-example.html",
+    "/blog/2015-01-08-on-http-middleware-and-psr-7.html",
+    "/blog/2014-11-03-utopic-and-amd.html",
+    "/blog/2014-09-18-zend-server-deployment-part-8.html"
 ];
 
 /* Cache up to 25 pages locally */

--- a/public/service-worker.js
+++ b/public/service-worker.js
@@ -2,11 +2,13 @@
 var version = 'v0.0.2:';
 
 /* Pages to cache by default */
+/* @generator-marker@ */
 var offline = [
   '/',
   '/offline',
   '/resume'
 ];
+/* @/generator-marker@ */
 
 /* Cache up to 25 pages locally */
 var pageCacheLimit = 25;

--- a/public/service-worker.js
+++ b/public/service-worker.js
@@ -1,0 +1,147 @@
+/* Ends with ':' so it can be used with cache identifiers */
+var version = 'v0.0.2:';
+
+/* Pages to cache by default */
+var offline = [
+  '/',
+  '/offline',
+  '/resume'
+];
+
+/* Cache up to 25 pages locally */
+var pageCacheLimit = 25;
+
+/* Cache up to 10 images locally */
+var imageCacheLimit = 10;
+
+/* Update/install the static cache */
+var updateStaticCache = function() {
+  return caches.open(version + 'offline').then(function(cache) {
+    return Promise.all(offline.map(function(value) {
+      var request = new Request(value);
+      var url = new URL(request.url);
+      if (url.origin != location.origin) {
+        request = new Request(value, {mode: 'no-cors'});
+      }
+      return fetch(request).then(function(response) {
+        var cachedCopy = response.clone();
+        return cache.put(request, cachedCopy);
+      });
+    }));
+  });
+};
+
+/* Invalidate obsolete cache entries */
+var clearOldCache = function() {
+  return caches.keys().then(function(keys) {
+    return Promise.all(
+      keys
+        .filter(function(key) {
+          return key.indexOf(version);
+        })
+        .map(function(key) {
+          return caches.delete(key);
+        })
+    );
+  });
+};
+
+/* Ensure cache only retains a set number of items */
+var limitCache = function(cache, maxItems) {
+  cache.keys().then(function(items) {
+    if (items.length > maxItems) {
+      cache.delete(items[0]);
+    }
+  });
+};
+
+/* Install the service worker: populate the cache */
+self.addEventListener('install', function(event) {
+  event.waitUntil(updateStaticCache());
+});
+
+/* On activation: clear out old cache files */
+self.addEventListener('activate', function(event) {
+  event.waitUntil(clearOldCache());
+});
+
+/* Handle fetch events, but only from GET */
+self.addEventListener('fetch', function(event) {
+  /* Fetch from site and cache on completion */
+  var fetchFromNetwork = function(response) {
+    var cacheCopy = response.clone();
+
+    /* Caching an HTML page */
+    if (event.request.headers.get('Accept').indexOf('text/html') != -1) {
+      caches.open(version + 'pages').then(function(cache) {
+        cache.put(event.request, cacheCopy).then(function() {
+          limitCache(cache, pageCacheLimit);
+        });
+      });
+      return response;
+    }
+
+    /* Caching an image */
+    if (event.request.headers.get('Accept').indexOf('image/') != -1) {
+      caches.open(version + 'images').then(function(cache) {
+        cache.put(event.request, cacheCopy).then(function() {
+          limitCache(cache, imageCacheLimit);
+        });
+      });
+      return response;
+    }
+
+    /* All other assets */
+    caches.open(version + 'assets').then(function(cache) {
+      cache.put(event.request, cacheCopy);
+    });
+    return response;
+  };
+
+  /* Provide a fallback in the event of network failure/going offline */
+  var fallback = function() {
+    /* HTML pages; check if in cache, returning that, or /offline if not found */
+    if (event.request.headers.get('Accept').indexOf('text/html') != -1) {
+      return caches.match(event.request).then(function(response) {
+        return response || caches.match('/offline');
+      });
+    }
+
+    /* Images: placeholder indicating offline */
+    if (event.request.headers.get('Accept').indexOf('image/') != -1) {
+      return new Response(
+        '<svg width="400" height="300" role="img" aria-labelledby="offline-title" viewBox="0 0 400 300" xmlns="http://www.w3.org/2000/svg"><title id="offline-title">Offline</title><g fill="none" fill-rule="evenodd"><path fill="#D8D8D8" d="M0 0h400v300H0z"/><text fill="#9B9B9B" font-family="Helvetica Neue,Arial,Helvetica,sans-serif" font-size="72" font-weight="bold"><tspan x="93" y="172">offline</tspan></text></g></svg>',
+        { 
+          headers: { 
+            'Content-Type': 'image/svg+xml'
+          }
+        }
+      );
+    }
+  };
+
+  /* If not a GET request, we're done; nothing to cache */
+  if (event.request.method != 'GET') {
+    return;
+  }
+
+  /* HTML requests: attempt to fetch from network first, falling back to cache */
+  if (event.request.headers.get('Accept').indexOf('text/html') != -1) {
+    /* Attempt to fetch from the network; fallback if it cannot be done.
+     *
+     * Essentially, fetch() returns a promise, and we're using fetchFromNetwork
+     * as the resolve callback, and fallback as the reject callback.
+     */
+    event.respondWith(fetch(event.request).then(fetchFromNetwork, fallback));
+    return;
+  }
+
+  /* Non-HTML requests: look for file in cache first */
+  event.respondWith(
+      caches.match(event.request).then(function(cached) {
+        return cached || fetch(event.request).then(fetchFromNetwork, fallback);
+      })
+  );
+});
+
+/* See https://brandonrozek.com/2015/11/service-workers/ for full details! */

--- a/src/Console/PrepOfflinePages.php
+++ b/src/Console/PrepOfflinePages.php
@@ -1,0 +1,118 @@
+<?php
+namespace Mwop\Console;
+
+use Mwop\Blog\MapperInterface;
+use Zend\Expressive\Router\RouterInterface;
+
+class PrepOfflinePages
+{
+    const MARKER_START = '/* @generator-marker@ */';
+    const MARKER_END   = '/* @generator-marker@ */';
+
+    /**
+     * @var array Default paths to always include in the service-worker
+     */
+    private $defaultPaths = [
+        '/',
+        '/offline',
+        '/resume',
+    ];
+
+    private $mapper;
+
+    private $router;
+
+    public function __construct(MapperInterface $mapper, RouterInterface $router)
+    {
+        $this->mapper = $mapper;
+        $this->router = $router;
+    }
+
+    public function __invoke($route, $console)
+    {
+        $serviceWorker = $route->getMatchedParam('serviceWorker');
+
+        $this->console->writeLine('Updating service worker default offline pages');
+
+        $paths = $this->defaultPaths;
+        foreach ($this->generatePaths() as $path) {
+            $paths[] = $path;
+        }
+
+        $this->updateServiceWorker($serviceWorker, $paths);
+
+        $this->console->writeLine('[DONE]');
+    }
+
+    /**
+     * Generator: first page of blog post URIs
+     *
+     * @return string[]
+     */
+    private function generatePaths()
+    {
+        $posts = $this->mapper->fetchAll();
+        $posts->setCurrentPageNumber(1);
+
+        foreach ($posts as $post) {
+            yield $this->generateUri('blog.post', $post['id']);
+        }
+    }
+
+    /**
+     * Normalize generated URIs.
+     *
+     * @param string $route
+     * @param string $id
+     * @return string
+     */
+    private function generateUri($route, $id)
+    {
+        $uri = $this->router->generateUri($route, ['id' => $id]);
+        return str_replace('[/]', '', $uri);
+    }
+
+    /**
+     * Update the service worker script contents
+     *
+     * @param string $serviceWorker Path to the service-worker.js script
+     * @param array $paths Default offline paths
+     */
+    private function updateServiceWorker($serviceWorker, array $paths)
+    {
+        if (! file_exists($serviceWorker)) {
+            throw new InvalidArgumentException(sprintf(
+                'Invalid service-worker path (%s); please provide a valid path to the service-worker',
+                $serviceWorker
+            ));
+        }
+
+        $contents = file_get_contents($serviceWorker);
+        $contents = $this->replaceOfflinePaths(json_encode($paths), $contents);
+        file_put_contents($serviceWorker, $contents);
+    }
+
+    /**
+     * Replace the offline paths variable contents in the service-worker.js
+     *
+     * @param string $paths JSON-encoded array of offline paths
+     * @param string $serviceWorker Contents of the service-worker.js file
+     * @return string
+     */
+    private function replaceOfflinePaths($paths, $serviceWorker)
+    {
+        $pattern  = sprintf(
+            "/^(%s[\r\n]+).*?([\r\n]+%s)$/s",
+            preg_quote(self::MARKER_START),
+            preg_quote(self::MARKER_END)
+        );
+        $replacement = sprintf(
+            "%s\nvar offline = %s;\n%s",
+            self::MARKER_START,
+            $paths,
+            self::MARKER_END
+        );
+
+        return preg_replace($pattern, $replacement, $serviceWorker);
+    }
+}

--- a/src/Console/PrepOfflinePages.php
+++ b/src/Console/PrepOfflinePages.php
@@ -15,6 +15,7 @@ class PrepOfflinePages
      */
     private $defaultPaths = [
         '/',
+        '/blog',
         '/offline',
         '/resume',
     ];

--- a/src/Factory/PrepOfflinePagesFactory.php
+++ b/src/Factory/PrepOfflinePagesFactory.php
@@ -1,7 +1,7 @@
 <?php
 namespace Mwop\Factory;
 
-use Mwop\Blog\MapperInterface;
+use Mwop\Blog\Mapper;
 use Mwop\Console\PrepOfflinePages;
 use Zend\Expressive\Router\RouterInterface;
 
@@ -10,7 +10,7 @@ class PrepOfflinePagesFactory
     public function __invoke($services, $canonicalName, $requestedName)
     {
         return new PrepOfflinePages(
-            $services->get(MapperInterface::class),
+            $services->get(Mapper::class),
             $services->get(RouterInterface::class)
         );
     }

--- a/src/Factory/PrepOfflinePagesFactory.php
+++ b/src/Factory/PrepOfflinePagesFactory.php
@@ -1,0 +1,17 @@
+<?php
+namespace Mwop\Factory;
+
+use Mwop\Blog\MapperInterface;
+use Mwop\Console\PrepOfflinePages;
+use Zend\Expressive\Router\RouterInterface;
+
+class PrepOfflinePagesFactory
+{
+    public function __invoke($services, $canonicalName, $requestedName)
+    {
+        return new PrepOfflinePages(
+            $services->get(MapperInterface::class),
+            $services->get(RouterInterface::class)
+        );
+    }
+}

--- a/templates/layout/layout.mustache
+++ b/templates/layout/layout.mustache
@@ -65,6 +65,7 @@
 {{$scripts}}{{/scripts}}
 <script src="//code.jquery.com/jquery-1.10.2.min.js"></script>
 <script src="/js/bootstrap.min.js"></script>
+<script src="/js/site.js"></script>
 <script type="text/javascript">
   $(document).ready(function() {
     $('#site-search').submit(function (event) {

--- a/templates/mwop/offline.page.mustache
+++ b/templates/mwop/offline.page.mustache
@@ -1,0 +1,17 @@
+{{<layout::layout}}
+{{$title}}Offline{{/title}}}
+{{$content}}
+<article class="offline col-md-6 col-md-offset-3">
+    <h2>Offline</h2>
+
+    <p>
+      Looks like you're operating offline at the moment! Please come again
+      when you have an internet connection!
+    </p>
+
+    <p>
+      You can always <a href="/">visit the homepage</a>.
+    </p>
+</article>
+{{/content}}
+{{/layout::layout}}


### PR DESCRIPTION
Used https://brandonrozek.com/2015/11/service-workers/ as a guide for setting up offline capabilities for the website. Currently, it caches the following pages out-of-the-box:

- home page
- resume
- offline page
- blog landing page
- all blog posts from the first page

Additionally, it will cache other pages as you visit them for the first time, using the following rules:

- it will cache up to 25 pages visited
- it will cache up to 10 images encountered
- it will cache any assets encountered